### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 These examples are provided as-is and are updated to present best practices
 for programming WebVR experiences against Carmel and other browsers.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ## Our Development Process
 
 Our examples are copied from an internal repository which is tracking the


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the Carmel-Starter-Kit community profile](https://github.com/facebook/Carmel-Starter-Kit/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1340" alt="screen shot 2017-11-26 at 2 31 25 pm" src="https://user-images.githubusercontent.com/1114467/33245006-a6437164-d2b6-11e7-92e3-3b4131af7604.png">
<img width="1329" alt="screen shot 2017-11-26 at 2 31 31 pm" src="https://user-images.githubusercontent.com/1114467/33245007-a65f42f4-d2b6-11e7-982e-d28a4a33b405.png">

**issue:**
internal task t23481323